### PR TITLE
feat: 콤보 UI 애니메이션 - Floating 연출, 시간 조정

### DIFF
--- a/Docs/이성규_문서정리/TEMFKing_작업노트_이성규.md
+++ b/Docs/이성규_문서정리/TEMFKing_작업노트_이성규.md
@@ -788,50 +788,72 @@ while 루프 안에서 `result.comboCount >= 2`일 때 콜백 호출.
 
 ### 퍼즐 리필 버그 수정
 
-퍼즐 리필이 안되고 빈칸이 되는 버그는 이펙트 실제 완료가 아닌 퍼즐 클리어 시점부터 일정시간 대기를 조건으로 삼아서 기존 로직에서 이펙트 추가시 동작을 고려안해서 생긴 버그로 지금 수정 작업.
+3매치 후 빈 슬롯에 블록이 채워지지 않고 영구적인 빈칸(유령 블록)이 남는 현상 수정.
 
-**문제**
-- 3매치 발생 후, 블록이 사라진 빈 슬롯만큼 위에서 블록이 내려와 채워져야 하나 간헐적으로 블록이 생성되지 않고 영구적인 빈칸(유령 블록)이 내려오는 현상 발생.
+**원인**
 
-**이유 (원인 분석)**
-- **비동기 이펙트 타이밍과 풀링 로직의 충돌**
-- 블록 파괴 이펙트 재생 시간 > 매치 후 대기 시간(`clearDelay`)일 때 발생.
-- 매치된 블록은 파괴(Despawn) 시 재활용 풀(`_recyclePool`)에 들어가며, 이펙트 재생을 위해 `activeSelf = true`, 상태는 `Destroying`으로 전환됨.
-- 이펙트가 채 끝나기도 전에 `clearDelay`가 만료되어 낙하 로직(`DropBlocks`)이 실행됨.
-- 기존 낙하 로직이 활성화 여부(`activeSelf`)만 체크했기 때문에, 이펙트 재생 중인 블록을 정상 활성 블록으로 오인하여 낙하 대상에 포함시킴.
-- 엉뚱한 위치로 이동(낙하) 또는 리필된 직후 이펙트 재생이 종료되며 뒤늦게 `SetActive(false)` 콜백이 불림.
-- 결과적으로 멀쩡히 떨어지던 블록이 공중에서 증발하고 보드에 영구적인 빈칸이 남게 됨.
+블록 파괴 이펙트 재생 시간이 `clearDelay`보다 길 때 발생하는 타이밍 문제.
 
-**해결 및 조치 흐름**
-- **1. 낙하 로직에 블록 상태(Status) 검증 추가**
-  - `DropBlocks` 수행 시 `block != null && block.gameObject.activeSelf` 조건에 `&& block.Status == EBlockStatus.None`을 추가하여 파괴 연출 중인 블록은 낙하 및 리필 대상에서 원천 배제.
-- **2. 이펙트 재생 및 로직 동기화**
-  - `ClearMatches` 대기 방식을 단순 딜레이(`clearDelay`) 대기가 아닌, `Despawn(Action onComplete)` 콜백 패턴으로 변경하여 실제 파괴 연출이 끝난 후 보드 갱신이 진행되도록 동기화 보장.
-- **3. 풀링 생명주기 찌꺼기(Tween) 정리**
-  - 낙하 중 연쇄 매치로 파괴되어 재활용될 경우를 대비해, `Block.cs`의 `Despawn`과 `Init` 메서드 최상단에 `DOTween.Kill(Rect)`을 호출하여 잔여 애니메이션으로 인한 좌표/상태 오염 방지.
-- **4. 이펙트 코루틴 고아화 방지**
-  - 외부 요인으로 블록이 비활성화될 때 이펙트 코루틴이 멈춰 전체 보드가 교착(Deadlock)에 빠지는 것을 막기 위해, `UIFrameEffect`에 `ForceStop` 메서드를 추가하여 중단 시에도 콜백 실행을 보장하도록 안전장치 마련.
+1. 매치된 블록이 `Despawn` → 이펙트 재생 시작 (`activeSelf = true`, `Status = Destroying`)
+2. 이펙트가 끝나기 전에 `clearDelay` 만료 → 낙하 로직 실행
+3. 낙하 로직이 `activeSelf`만 체크해서 이펙트 재생 중인 블록을 정상 블록으로 오인, 낙하 대상에 포함
+4. 이펙트 종료 콜백이 뒤늦게 `SetActive(false)` 호출 → 이미 낙하/리필된 블록이 증발, 영구 빈칸 발생
 
-**요약**
+**수정 내역**
 
----
+| 파일 | 수정 | 목적 |
+|------|------|------|
+| **UIFrameEffect** | `_runningCoroutine` 참조 추적 + `ForceStopEffect()` 추가 | 코루틴 중복 재생 방지 + 강제 중단 시 콜백 보장 |
+| **Block** | `Despawn(Action onComplete)` 콜백 파라미터 추가 | 이펙트 완료 시점을 외부에 알림 |
+| **Block** | `Init`/`Despawn`에 `DOTween.Kill(Rect)` 추가 | 재활용 시 잔여 Tween의 상태 오염 방지 |
+| **Block** | `Init`에서 `ForceStopEffect()` + `_blockImage.enabled = true` | 이펙트 고아 코루틴 방지 + 숨겨진 이미지 복원 |
+| **BoardProcessor** | `ClearMatches` → `remaining` 카운트다운 콜백 패턴 | 모든 Despawn 실제 완료 후 다음 단계 진행 |
+| **BoardProcessor** | `clearDelay` + `WaitUntil(clearDone)` 이중 대기 | 최소 연출 대기 보장 + 이펙트가 더 길면 완료까지 추가 대기 |
+| **BoardProcessor** | `DropBlocks`에 `Status == EBlockStatus.None` 조건 추가 | Destroying 상태 블록 낙하 제외 (방어적 이중 안전장치) |
 
-- **핵심 원인:** 파괴 이펙트 연출 시간이 보드 대기 시간(`clearDelay`)보다 길어서 발생한 타이밍 꼬임 현상.
-- **오류 흐름:** 파괴 연출을 위해 활성화(`activeSelf`) 상태로 둔 블록을 낙하 로직이 '정상 블록'으로 오인하여 강제로 낙하/리필 대상에 포함시킴.
-- **최종 결과:** 재활용되어 새 위치로 떨어지던 블록이 뒤늦게 발동한 이펙트 종료 콜백(`SetActive(false)`)에 의해 공중에서 증발하며 영구적인 빈칸 생성.
+**극한 테스트 (전체 통과)**
+
+1. **달팽이 이펙트**: 이펙트 FPS 1~2 (3~5초), clearDelay 0 → 이펙트 완료까지 대기, 유령 블록 없음
+2. **긴 딜레이**: 이펙트 FPS 60 (0.1초), clearDelay 3초 → 이펙트 종료 후 3초 정적 대기 후 낙하
+3. **머신건 콤보**: clearDelay 0.05, dropDuration 0.01, refillDelay 0 → 고속 연쇄 중 상태 오염 없이 정상 완료
 
 ---
 
-리필 딜레이를 줄이면 루프 전체 사이클이 빨라지니까, clearDelay 시간 내에 이펙트가 끝나지 못하는 확률이 상대적으로 높아져서 재현이 쉬워진다.
-원인은 같다 — 고정 딜레이 기반의 타이밍 의존 문제. 수정한 3개 파일을 적용하면 clearDelay를 아예 안 쓰고 실제 Despawn 완료 콜백으로 대기하기 때문에, refillDelay를 얼마로 설정하든 클리어→낙하 순서가 깨지지 않는다.
+### 콤보 UI 애니메이션
 
-clearDelay는 역할을 축소해서 매치 인지용으로 말그대로 클리어 후 딜레이에 사용한다.
+기획 명세: 퍼즐판 중앙에 콤보 텍스트 출력, 커졌다가 작아지면서 위로 떠오르는 Floating 연출, 지속시간 1초.
 
-수정 정리
+**수정 전 상태**
+ 
+- 콤보 중복 출력 방지 (`_currentSequence?.Kill()` 후 덮어쓰기) → OK
+- 첫 매치 미표기, X2부터 출력 → BoardManager 쪽 책임 → OK
+- `OnChainComplete`로 연쇄 종료 시 즉시 숨김 → OK
+- Floating 연출 → **미구현**. `_originalPosition` 캐싱만 해놓고 Y 이동 Tween 없음
+- 지속시간 → `_displayDuration` 1.5f + fadeIn/Out 합치면 약 2초. 명세 1초 초과
+ 
+**Binder 람다 리스너 해제 버그**
+ 
+`OnPuzzleComplete`에 람다 `_ => _display.OnChainComplete()`로 AddListener, OnDisable에서 새 람다로 RemoveListener → 다른 인스턴스라 해제 안 됨.
+Awake에서 `UnityAction<PuzzleResult>` 래퍼 캐싱, 동일 참조로 Add/Remove하도록 수정.
+ 
+**연출 시간 조정**
+ 
+매칭 클리어 간격이 약 0.3초로 빠른 편이라, 기획서 1초 기준으로는 다음 콤보 갱신 전에 이전 텍스트가 채 사라지지 않음.
+실제 게임 템포에 맞춰 총 0.5초(페이드인 0.05 / 유지 0.25 / 페이드아웃 0.2)로 조정.
+다음 매치 진입 시 기존 연출 즉시 Kill → 갱신하므로 겹침 없음.
+ 
+**최종 연출 흐름 (DOTween Sequence)**
+ 
+```
+1. 페이드인 (0.05s): alpha 0→1 + 스케일 0→1 (OutBack 오버슈트)
+2. 대기 (0.25s): 선명한 상태 유지
+3. 상승 + 페이드아웃: floatDistance만큼 Y 이동 (OutCubic, 0.2s)
+   페이드아웃은 Insert로 등장+대기 이후 시점에 끼워넣어 상승 중 서서히 사라짐
+```
 
-**UIFrameEffect.cs**
+---
 
-- _runningCoroutine 필드 추가 — 코루틴 참조 추적
-- PlayEffect: 이전 재생이 남아있으면 StopCoroutine으로 정리 후 새로 시작
-- PlayFrames: 정상 완료 시 _runningCoroutine = null 초기화
-- ForceStopEffect() 메서드 추가 — 외부에서 강제 중단 시 코루틴 정리 + 콜백 보장
+### 콤보 TMP Raycast Target 수정
+ 
+콤보 텍스트 TMP에 Raycast Target이 켜져 있어서 퍼즐판 위의 블록 드래그 입력을 가로채는 문제.
+→ `_comboText`의 Raycast Target OFF 처리.

--- a/EOF/Assets/Scenes/LSG/LSGTestScene.unity
+++ b/EOF/Assets/Scenes/LSG/LSGTestScene.unity
@@ -1464,10 +1464,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: Canvas_PuzzleBoard_111
       objectReference: {fileID: 0}
-    - target: {fileID: 4488388279573438189, guid: d5394c00ffc34c8498163ed2796f7e43, type: 3}
-      propertyPath: _animSettings.clearDelay
-      value: 1
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []

--- a/EOF/Assets/Scenes/LSG/Prefabs/Canvas_PuzzleBoard_111.prefab
+++ b/EOF/Assets/Scenes/LSG/Prefabs/Canvas_PuzzleBoard_111.prefab
@@ -614,7 +614,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
+  m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
@@ -2348,9 +2348,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::ComboDisplayUI
   _comboText: {fileID: 3636737169637188890}
   _canvasGroup: {fileID: 8199638983951110286}
-  _displayDuration: 1.5
-  _fadeInDuration: 0.15
-  _fadeOutDuration: 0.3
+  _displayDuration: 0.25
+  _fadeInDuration: 0.05
+  _fadeOutDuration: 0.2
+  _floatDistance: 60
 --- !u!114 &6406487826396215431
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/EOF/Assets/Scripts/Puzzle/Effect/ComboDisplayBinder.cs
+++ b/EOF/Assets/Scripts/Puzzle/Effect/ComboDisplayBinder.cs
@@ -8,21 +8,25 @@ public class ComboDisplayBinder : MonoBehaviour
     [SerializeField] private BoardManager _boardManager;
 
     private ComboDisplayUI _display;
-
+    
+    // OnPuzzleComplete에 맞춘 래퍼 - 람다 대신 캐싱하여 Remove 가능
+    private UnityEngine.Events.UnityAction<PuzzleResult> _onPuzzleComplete;
+    
     private void Awake()
     {
         _display = GetComponent<ComboDisplayUI>();
+        _onPuzzleComplete = _ => _display.OnChainComplete();
     }
     
     private void OnEnable()
     {
         _boardManager.OnComboUpdated.AddListener(_display.OnComboUpdated);
-        _boardManager.OnPuzzleComplete.AddListener(_ => _display.OnChainComplete());
+        _boardManager.OnPuzzleComplete.AddListener(_onPuzzleComplete);
     }
 
     private void OnDisable()
     {
         _boardManager.OnComboUpdated.RemoveListener(_display.OnComboUpdated);
-        _boardManager.OnPuzzleComplete.RemoveListener(_ => _display.OnChainComplete());
+        _boardManager.OnPuzzleComplete.RemoveListener(_onPuzzleComplete);
     }
 }

--- a/EOF/Assets/Scripts/Puzzle/Effect/ComboDisplayUI.cs
+++ b/EOF/Assets/Scripts/Puzzle/Effect/ComboDisplayUI.cs
@@ -12,25 +12,37 @@ public class ComboDisplayUI : MonoBehaviour
     
     [Header("Settings")]
     [Tooltip("화면에 유지되는 대기 시간. (초 단위)")]
-    [SerializeField] private float _displayDuration = 1.5f;
+    [SerializeField] private float _displayDuration = 0.25f;
     [Tooltip("콤보 텍스트가 팝업되며 나타나는 데 걸리는 시간")]
-    [SerializeField] private float _fadeInDuration = 0.15f;
+    [SerializeField] private float _fadeInDuration = 0.05f;
     [Tooltip("콤보 텍스트가 서서히 사라지는 데 걸리는 시간")]
-    [SerializeField] private float _fadeOutDuration = 0.3f;
+    [SerializeField] private float _fadeOutDuration = 0.2f;
+    
+    [Header("Floating")]
+    [Tooltip("위로 떠오르는 거리 (px)")]
+    [SerializeField] private float _floatDistance = 60f;
     
     private Sequence _currentSequence;
-
+    private Vector2 _originalPosition; // 콤보 애니메이션 적용 전 원래 위치
+    
     private void Awake()
     {
         if (_canvasGroup == null)
             _canvasGroup = GetComponent<CanvasGroup>();
-
+        
+        // 플로팅 연출 후 다음 콤보 때 원래 위치로 되돌리기 위해 캐싱
+        _originalPosition = _comboText.rectTransform.anchoredPosition;
+        
         // 초기 상태: 숨김
         _canvasGroup.alpha = 0f;
         _comboText.text = "";
     }
 
-    // BoardManager.OnComboUpdated 이벤트에 연결
+    /// <summary>
+    /// BoardManager.OnComboUpdated 이벤트에 연결.
+    /// 연출 흐름: 페이드인 + 스케일 등장 -> 유지하며 상승 시작 -> 마지막 구간에서 페이드아웃
+    /// </summary>
+
     public void OnComboUpdated(int comboCount)
     {
         // 기존 연출 중이면 즉시 종료
@@ -39,20 +51,35 @@ public class ComboDisplayUI : MonoBehaviour
         // 텍스트 갱신
         _comboText.text = $"X{comboCount}";
         
-        // 연출: 페이드인 + 펀치 스케일 -> 유지 -> 페이드아웃
-        // 콤보 텍스트 등장시 스케일 0, 투명도 0으로 세팅
+        // 연출 시작(콤보 텍스트 등장)시 위치, 스케일, 투명도 강제 초기화
+        _comboText.rectTransform.anchoredPosition = _originalPosition;
         _comboText.transform.localScale = Vector3.zero;
         _canvasGroup.alpha = 0f; 
         
+        // 연출: 페이드인 + 펀치 스케일 -> 유지하며 서서히 상승 -> 마지막에 페이드아웃
         _currentSequence = DOTween.Sequence()
-            // 1. 투명도는 0에서 1로 서서히 켜짐
+            // 1. 투명도는 0에서 1로 서서히 켜짐 (페이드인)
             .Append(_canvasGroup.DOFade(1f, _fadeInDuration))
-            // 2. 스케일은 0에서 1로 커지는데, Ease.OutBack 덕분에 1.2 정도까지 커졌다가 1로 돌아옴 (펀치 느낌)
-            .Join(_comboText.transform.DOScale(Vector3.one, _fadeInDuration).SetEase(Ease.OutBack))
-            // 3. 화면에 머무는 시간
+            // 2. 스케일은 0에서 1로 커지는데, Ease.OutBack 덕분에 살짝 커졌다가 1로 돌아옴 (펀치 느낌)
+            .Join(
+                _comboText.transform
+                    .DOScale(Vector3.one, _fadeInDuration)
+                    .SetEase(Ease.OutBack)
+            )
+            // 3. 화면에 머무는 시간 (대기)
             .AppendInterval(_displayDuration)
-            // 4. 서서히 사라짐
-            .Append(_canvasGroup.DOFade(0f, _fadeOutDuration))
+            // 4. 대기 직후부터 floatDistance만큼 상승 (대기+페이드아웃 전체 구간)
+            // OutCubic: 처음에 빠르게 올라가고 끝에서 감속
+            .Append(
+                _comboText.rectTransform
+                    .DOAnchorPosY(_originalPosition.y + _floatDistance, _fadeOutDuration)
+                    .SetEase(Ease.OutCubic)
+            ) 
+            // 5. 등장+대기 이후 시점에 페이드아웃을 끼워넣어 상승 중 서서히 사라지게 함
+            .Insert(
+                _fadeInDuration + _displayDuration, 
+                _canvasGroup.DOFade(0f, _fadeOutDuration)
+            )
             .OnKill(() => _currentSequence = null);
     }
 


### PR DESCRIPTION
- Floating 연출 추가 (DOAnchorPosY + Insert 페이드아웃)
- 연출 시간 조정: 1초 → 0.5초 (매칭 간격 0.3초에 맞춤)
- ComboDisplayBinder 람다 리스너 해제 버그 수정 (캐싱 래퍼 방식)
- 콤보 TMP Raycast Target OFF (블록 드래그 입력 가로채기 방지)