### PR TITLE
플레이어 상태이상 버그 수정

### DIFF
--- a/EOF/Assets/Scripts/System/BattleSystem.cs
+++ b/EOF/Assets/Scripts/System/BattleSystem.cs
@@ -79,6 +79,11 @@ public class BattleSystem : MonoBehaviour
             {
                 _boardManager.SetInteractable(true);
                 _player._behavior = _player._maxbehavior;
+                if (_player._freeze)
+                {
+                    _player._behavior--;
+                    _player._freeze = false;
+                }
                 while (_player._behavior > 0)
                 {
                     yield return new WaitUntil(() => _isSwap || _isPuzzle);
@@ -90,7 +95,6 @@ public class BattleSystem : MonoBehaviour
                         timeout -= Time.deltaTime;
                         yield return null; 
                     }
-                    
                     while (_boardManager.IsProcessing)
                     {
                         yield return null;
@@ -122,12 +126,6 @@ public class BattleSystem : MonoBehaviour
                     }
                     _isPuzzle = false;
                     _isSwap = false;
-                    if (_player._freeze)
-                    {
-                        _player._behavior--;
-                        _player._freeze = false;
-                        continue;
-                    }
 
                     if (_player._theEnd) _player.ReceiveDamage(5f);
                     while (_player._behavioralGauge >= _player._maxbehavioralGauge)


### PR DESCRIPTION
블루드래곤이 프로스트브래스를 쏘면 상태이상이 적용되어 퍼즐잠금을 한 상태에서 컨티뉴를 해서 생긴 버그였습니다