### PR TITLE
LSG_아틀라스 설정

### DIFF
--- a/Docs/이성규_문서정리/TEMFKing_작업노트_이성규.md
+++ b/Docs/이성규_문서정리/TEMFKing_작업노트_이성규.md
@@ -3,7 +3,7 @@
 **작성자**: 이성규  
 **게임명**: 스러진 왕의 영원한 행진(The Eternal March of the Fallen King)  
 **작성일**: 2026-03-23  
-**최종 수정**: 2026-03-26  
+**최종 수정**: 2026-04-07  
 
 ## 프로젝트 개요
 
@@ -917,3 +917,20 @@ PlayerPrefs 영구 저장은 기획상 배제, 런타임에 MixerVolumeControlle
 - SoundManager: AudioSource 생성 + Addressable 믹서 로드 + 재생 API
 - MixerVolumeController: AudioMixer 볼륨 설정/조회 (순수 C#)
 - VolumeSlider: UI Slider ↔ MixerVolumeController 바인딩 (MonoBehaviour)
+
+## Day 13 - 2026-04-07
+
+폴리싱 작업 서포트 및 문서정리
+
+### 스프라이트 아틀라스 패킹 작업 진행
+
+아틀라스로 묶을 수 있는 스프라이트들 아틀라스 패킹
+
+아틀라스에 들어가는 파일은 이중 압축이 되니 원본 에셋 압축은 None으로 설정
+
+AllowRotation 체크 해제  
+UI가 회전되어 출력되는 현상 방지
+
+외부 에셋스토어 에셋은 관리가 어려우니 아틀라스 패킹 고려 대상에서 제외
+
+퍼즐과 스킬아이콘, 통상적으로 자주 사용되는 이미지들을 각자 아틀라스로 패킹함

--- a/EOF/Assets/Atlas.meta
+++ b/EOF/Assets/Atlas.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 907722359e2bacc4aa9aebc5a6c41c16
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/EOF/Assets/Atlas/A lot of useful icons_03_Atlas.spriteatlasv2
+++ b/EOF/Assets/Atlas/A lot of useful icons_03_Atlas.spriteatlasv2
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!612988286 &1
+SpriteAtlasAsset:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 2
+  m_MasterAtlas: {fileID: 0}
+  m_ImporterData:
+    packables:
+    - {fileID: 102900000, guid: dcf8b55449f5cca4b8ba8e09d7cc78b7, type: 3}
+    - {fileID: 102900000, guid: 671f5395e39db904eacbc858e9c2b2c3, type: 3}
+  m_IsVariant: 0
+  m_ScriptablePacker: {fileID: 0}

--- a/EOF/Assets/Atlas/A lot of useful icons_03_Atlas.spriteatlasv2.meta
+++ b/EOF/Assets/Atlas/A lot of useful icons_03_Atlas.spriteatlasv2.meta
@@ -1,0 +1,30 @@
+fileFormatVersion: 2
+guid: 38edf705cb0c35e45972f6700e5c9abf
+SpriteAtlasImporter:
+  externalObjects: {}
+  textureSettings:
+    serializedVersion: 2
+    anisoLevel: 1
+    compressionQuality: 50
+    maxTextureSize: 2048
+    textureCompression: 0
+    filterMode: 1
+    generateMipMaps: 0
+    readable: 0
+    crunchedCompression: 0
+    sRGB: 1
+  platformSettings: []
+  packingSettings:
+    serializedVersion: 2
+    padding: 4
+    blockOffset: 1
+    allowAlphaSplitting: 0
+    enableRotation: 0
+    enableTightPacking: 0
+    enableAlphaDilation: 0
+  secondaryTextureSettings: {}
+  variantMultiplier: 1
+  bindAsDefault: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/EOF/Assets/Atlas/BlockSpriteAtlas.spriteatlasv2
+++ b/EOF/Assets/Atlas/BlockSpriteAtlas.spriteatlasv2
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!612988286 &1
+SpriteAtlasAsset:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 2
+  m_MasterAtlas: {fileID: 0}
+  m_ImporterData:
+    packables:
+    - {fileID: 2800000, guid: 9ed35e69d926bc14ea3a0d8e0c15b27f, type: 3}
+    - {fileID: 2800000, guid: 6ec6d34053a0dcd4296740f3a6017576, type: 3}
+    - {fileID: 2800000, guid: d61de55b173fc0c4f9cea9a8068b2f9b, type: 3}
+    - {fileID: 2800000, guid: f677972a5cb6ffb428a709354f045b16, type: 3}
+    - {fileID: 2800000, guid: 2c3f355a66cb5de4eafea1fc1c43258e, type: 3}
+  m_IsVariant: 0
+  m_ScriptablePacker: {fileID: 0}

--- a/EOF/Assets/Atlas/BlockSpriteAtlas.spriteatlasv2.meta
+++ b/EOF/Assets/Atlas/BlockSpriteAtlas.spriteatlasv2.meta
@@ -1,0 +1,30 @@
+fileFormatVersion: 2
+guid: 30c2d6e6406895b48a07c0517491b233
+SpriteAtlasImporter:
+  externalObjects: {}
+  textureSettings:
+    serializedVersion: 2
+    anisoLevel: 1
+    compressionQuality: 50
+    maxTextureSize: 2048
+    textureCompression: 0
+    filterMode: 1
+    generateMipMaps: 0
+    readable: 0
+    crunchedCompression: 0
+    sRGB: 1
+  platformSettings: []
+  packingSettings:
+    serializedVersion: 2
+    padding: 4
+    blockOffset: 1
+    allowAlphaSplitting: 0
+    enableRotation: 0
+    enableTightPacking: 0
+    enableAlphaDilation: 0
+  secondaryTextureSettings: {}
+  variantMultiplier: 1
+  bindAsDefault: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/EOF/Assets/Atlas/CommonUIAtlas.spriteatlasv2
+++ b/EOF/Assets/Atlas/CommonUIAtlas.spriteatlasv2
@@ -1,0 +1,26 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!612988286 &1
+SpriteAtlasAsset:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 2
+  m_MasterAtlas: {fileID: 0}
+  m_ImporterData:
+    packables:
+    - {fileID: 2800000, guid: a41aeb8b23c350344bf9ecfc74209bc5, type: 3}
+    - {fileID: 2800000, guid: bf42909247e8a5e49a43857e703d2b7e, type: 3}
+    - {fileID: 2800000, guid: 49f037dae2e3ab94c8ad562d2851cddc, type: 3}
+    - {fileID: 2800000, guid: 8ed296723b36fe0478e92842e9b0a16b, type: 3}
+    - {fileID: 2800000, guid: e2422559ae7734b46ba9669b1b53011e, type: 3}
+    - {fileID: 2800000, guid: 29ca397f9678a5641bfd3ffa1316cbe5, type: 3}
+    - {fileID: 2800000, guid: 6a2eaad662487e946bdccfd2f5b0da6e, type: 3}
+    - {fileID: 2800000, guid: 29da45dc7a0709c439d625bbc3d34fa9, type: 3}
+    - {fileID: 2800000, guid: 5a664431bc7fa764292fcf73b5535ca7, type: 3}
+    - {fileID: 2800000, guid: 40700f118e8e05f4c930a68b2f60b1de, type: 3}
+    - {fileID: 2800000, guid: e101ed38980ff1c4a88497b58b1399ff, type: 3}
+  m_IsVariant: 0
+  m_ScriptablePacker: {fileID: 0}

--- a/EOF/Assets/Atlas/CommonUIAtlas.spriteatlasv2.meta
+++ b/EOF/Assets/Atlas/CommonUIAtlas.spriteatlasv2.meta
@@ -1,0 +1,30 @@
+fileFormatVersion: 2
+guid: fd79cc8c87c9e744a9b4785372ed017b
+SpriteAtlasImporter:
+  externalObjects: {}
+  textureSettings:
+    serializedVersion: 2
+    anisoLevel: 1
+    compressionQuality: 50
+    maxTextureSize: 2048
+    textureCompression: 0
+    filterMode: 1
+    generateMipMaps: 0
+    readable: 0
+    crunchedCompression: 0
+    sRGB: 1
+  platformSettings: []
+  packingSettings:
+    serializedVersion: 2
+    padding: 4
+    blockOffset: 1
+    allowAlphaSplitting: 0
+    enableRotation: 0
+    enableTightPacking: 0
+    enableAlphaDilation: 0
+  secondaryTextureSettings: {}
+  variantMultiplier: 1
+  bindAsDefault: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/EOF/Assets/Atlas/Map_NodeAtlas.spriteatlasv2
+++ b/EOF/Assets/Atlas/Map_NodeAtlas.spriteatlasv2
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!612988286 &1
+SpriteAtlasAsset:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 2
+  m_MasterAtlas: {fileID: 0}
+  m_ImporterData:
+    packables:
+    - {fileID: 102900000, guid: 10ba959aadfa78540a174b6fdc5d3ddc, type: 3}
+  m_IsVariant: 0
+  m_ScriptablePacker: {fileID: 0}

--- a/EOF/Assets/Atlas/Map_NodeAtlas.spriteatlasv2.meta
+++ b/EOF/Assets/Atlas/Map_NodeAtlas.spriteatlasv2.meta
@@ -1,0 +1,30 @@
+fileFormatVersion: 2
+guid: c6580bb36218b424fbee268691da7d2c
+SpriteAtlasImporter:
+  externalObjects: {}
+  textureSettings:
+    serializedVersion: 2
+    anisoLevel: 1
+    compressionQuality: 50
+    maxTextureSize: 2048
+    textureCompression: 0
+    filterMode: 1
+    generateMipMaps: 0
+    readable: 0
+    crunchedCompression: 0
+    sRGB: 1
+  platformSettings: []
+  packingSettings:
+    serializedVersion: 2
+    padding: 4
+    blockOffset: 1
+    allowAlphaSplitting: 0
+    enableRotation: 0
+    enableTightPacking: 0
+    enableAlphaDilation: 0
+  secondaryTextureSettings: {}
+  variantMultiplier: 1
+  bindAsDefault: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/EOF/Assets/Atlas/PuzzleEffectAtlas.spriteatlasv2
+++ b/EOF/Assets/Atlas/PuzzleEffectAtlas.spriteatlasv2
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!612988286 &1
+SpriteAtlasAsset:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 2
+  m_MasterAtlas: {fileID: 0}
+  m_ImporterData:
+    packables:
+    - {fileID: 102900000, guid: cba762622ae931a4f9808dfd7f28e14e, type: 3}
+    - {fileID: 102900000, guid: c3ef971ce8084bc4fb5f2568368fb0af, type: 3}
+    - {fileID: 102900000, guid: b1c23eccd7279564eb69a3c2358e4f4a, type: 3}
+    - {fileID: 102900000, guid: 418490e0d8e39224cb31037aaafbe1c1, type: 3}
+  m_IsVariant: 0
+  m_ScriptablePacker: {fileID: 0}

--- a/EOF/Assets/Atlas/PuzzleEffectAtlas.spriteatlasv2.meta
+++ b/EOF/Assets/Atlas/PuzzleEffectAtlas.spriteatlasv2.meta
@@ -1,0 +1,43 @@
+fileFormatVersion: 2
+guid: 13bcfd646aa939f4d8140ce1cf6f4886
+SpriteAtlasImporter:
+  externalObjects: {}
+  textureSettings:
+    serializedVersion: 2
+    anisoLevel: 1
+    compressionQuality: 50
+    maxTextureSize: 2048
+    textureCompression: 0
+    filterMode: 1
+    generateMipMaps: 0
+    readable: 0
+    crunchedCompression: 0
+    sRGB: 1
+  platformSettings:
+  - serializedVersion: 4
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  packingSettings:
+    serializedVersion: 2
+    padding: 4
+    blockOffset: 1
+    allowAlphaSplitting: 0
+    enableRotation: 0
+    enableTightPacking: 0
+    enableAlphaDilation: 0
+  secondaryTextureSettings: {}
+  variantMultiplier: 1
+  bindAsDefault: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/EOF/Assets/Atlas/SkillIconsAtals.spriteatlasv2
+++ b/EOF/Assets/Atlas/SkillIconsAtals.spriteatlasv2
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!612988286 &1
+SpriteAtlasAsset:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 2
+  m_MasterAtlas: {fileID: 0}
+  m_ImporterData:
+    packables:
+    - {fileID: 102900000, guid: e928ae21ef1640c4cb424c8cdc7405bf, type: 3}
+  m_IsVariant: 0
+  m_ScriptablePacker: {fileID: 0}

--- a/EOF/Assets/Atlas/SkillIconsAtals.spriteatlasv2.meta
+++ b/EOF/Assets/Atlas/SkillIconsAtals.spriteatlasv2.meta
@@ -1,0 +1,30 @@
+fileFormatVersion: 2
+guid: fee936299280de041a9366b6433c44aa
+SpriteAtlasImporter:
+  externalObjects: {}
+  textureSettings:
+    serializedVersion: 2
+    anisoLevel: 1
+    compressionQuality: 50
+    maxTextureSize: 2048
+    textureCompression: 0
+    filterMode: 1
+    generateMipMaps: 0
+    readable: 0
+    crunchedCompression: 0
+    sRGB: 1
+  platformSettings: []
+  packingSettings:
+    serializedVersion: 2
+    padding: 4
+    blockOffset: 1
+    allowAlphaSplitting: 0
+    enableRotation: 0
+    enableTightPacking: 0
+    enableAlphaDilation: 0
+  secondaryTextureSettings: {}
+  variantMultiplier: 1
+  bindAsDefault: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/EOF/Assets/Atlas/TitleAtlas.spriteatlasv2
+++ b/EOF/Assets/Atlas/TitleAtlas.spriteatlasv2
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!612988286 &1
+SpriteAtlasAsset:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 2
+  m_MasterAtlas: {fileID: 0}
+  m_ImporterData:
+    packables:
+    - {fileID: 2800000, guid: 4e88c3438da2fcc4f8ae7e3ddc089ec9, type: 3}
+    - {fileID: 2800000, guid: e8931f3b434883f4c91179b7faacc116, type: 3}
+    - {fileID: 2800000, guid: e101ed38980ff1c4a88497b58b1399ff, type: 3}
+    - {fileID: 2800000, guid: de2bad0a7decde14d9114adb3a5d9545, type: 3}
+  m_IsVariant: 0
+  m_ScriptablePacker: {fileID: 0}

--- a/EOF/Assets/Atlas/TitleAtlas.spriteatlasv2.meta
+++ b/EOF/Assets/Atlas/TitleAtlas.spriteatlasv2.meta
@@ -1,0 +1,30 @@
+fileFormatVersion: 2
+guid: 376fcaf1b9c179743a520f6c51a4ff3d
+SpriteAtlasImporter:
+  externalObjects: {}
+  textureSettings:
+    serializedVersion: 2
+    anisoLevel: 1
+    compressionQuality: 50
+    maxTextureSize: 2048
+    textureCompression: 0
+    filterMode: 1
+    generateMipMaps: 0
+    readable: 0
+    crunchedCompression: 0
+    sRGB: 1
+  platformSettings: []
+  packingSettings:
+    serializedVersion: 2
+    padding: 4
+    blockOffset: 1
+    allowAlphaSplitting: 0
+    enableRotation: 0
+    enableTightPacking: 0
+    enableAlphaDilation: 0
+  secondaryTextureSettings: {}
+  variantMultiplier: 1
+  bindAsDefault: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/EOF/Assets/Atlas/death_ange_Atlas.spriteatlasv2
+++ b/EOF/Assets/Atlas/death_ange_Atlas.spriteatlasv2
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!612988286 &1
+SpriteAtlasAsset:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 2
+  m_MasterAtlas: {fileID: 0}
+  m_ImporterData:
+    packables:
+    - {fileID: 102900000, guid: 1b6fd3343b618417ea59c1978ea20241, type: 3}
+  m_IsVariant: 0
+  m_ScriptablePacker: {fileID: 0}

--- a/EOF/Assets/Atlas/death_ange_Atlas.spriteatlasv2.meta
+++ b/EOF/Assets/Atlas/death_ange_Atlas.spriteatlasv2.meta
@@ -1,0 +1,43 @@
+fileFormatVersion: 2
+guid: 5b664ef7a4dac214493cce9701a2da4f
+SpriteAtlasImporter:
+  externalObjects: {}
+  textureSettings:
+    serializedVersion: 2
+    anisoLevel: 1
+    compressionQuality: 50
+    maxTextureSize: 2048
+    textureCompression: 0
+    filterMode: 1
+    generateMipMaps: 0
+    readable: 0
+    crunchedCompression: 0
+    sRGB: 1
+  platformSettings:
+  - serializedVersion: 4
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    ignorePlatformSupport: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  packingSettings:
+    serializedVersion: 2
+    padding: 4
+    blockOffset: 1
+    allowAlphaSplitting: 0
+    enableRotation: 0
+    enableTightPacking: 0
+    enableAlphaDilation: 0
+  secondaryTextureSettings: {}
+  variantMultiplier: 1
+  bindAsDefault: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/EOF/Assets/Atlas/legendary-dragon_Atlas.spriteatlasv2
+++ b/EOF/Assets/Atlas/legendary-dragon_Atlas.spriteatlasv2
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!612988286 &1
+SpriteAtlasAsset:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 2
+  m_MasterAtlas: {fileID: 0}
+  m_ImporterData:
+    packables:
+    - {fileID: 102900000, guid: 0fc00eac5f5fb41ce9253f468430d4d7, type: 3}
+  m_IsVariant: 0
+  m_ScriptablePacker: {fileID: 0}

--- a/EOF/Assets/Atlas/legendary-dragon_Atlas.spriteatlasv2.meta
+++ b/EOF/Assets/Atlas/legendary-dragon_Atlas.spriteatlasv2.meta
@@ -1,0 +1,30 @@
+fileFormatVersion: 2
+guid: 436a515e1b8581649a57bf87e90cd621
+SpriteAtlasImporter:
+  externalObjects: {}
+  textureSettings:
+    serializedVersion: 2
+    anisoLevel: 1
+    compressionQuality: 50
+    maxTextureSize: 2048
+    textureCompression: 0
+    filterMode: 1
+    generateMipMaps: 0
+    readable: 0
+    crunchedCompression: 0
+    sRGB: 1
+  platformSettings: []
+  packingSettings:
+    serializedVersion: 2
+    padding: 4
+    blockOffset: 1
+    allowAlphaSplitting: 0
+    enableRotation: 0
+    enableTightPacking: 0
+    enableAlphaDilation: 0
+  secondaryTextureSettings: {}
+  variantMultiplier: 1
+  bindAsDefault: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/EOF/Assets/Atlas/orc_warriorAtlas.spriteatlasv2
+++ b/EOF/Assets/Atlas/orc_warriorAtlas.spriteatlasv2
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!612988286 &1
+SpriteAtlasAsset:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 2
+  m_MasterAtlas: {fileID: 0}
+  m_ImporterData:
+    packables:
+    - {fileID: 102900000, guid: 7c719dfb7050240fea4b50dfb0cdd100, type: 3}
+  m_IsVariant: 0
+  m_ScriptablePacker: {fileID: 0}

--- a/EOF/Assets/Atlas/orc_warriorAtlas.spriteatlasv2.meta
+++ b/EOF/Assets/Atlas/orc_warriorAtlas.spriteatlasv2.meta
@@ -1,0 +1,30 @@
+fileFormatVersion: 2
+guid: 2325d7af1fa400046881a25c678f63b5
+SpriteAtlasImporter:
+  externalObjects: {}
+  textureSettings:
+    serializedVersion: 2
+    anisoLevel: 1
+    compressionQuality: 50
+    maxTextureSize: 2048
+    textureCompression: 0
+    filterMode: 1
+    generateMipMaps: 0
+    readable: 0
+    crunchedCompression: 0
+    sRGB: 1
+  platformSettings: []
+  packingSettings:
+    serializedVersion: 2
+    padding: 4
+    blockOffset: 1
+    allowAlphaSplitting: 0
+    enableRotation: 1
+    enableTightPacking: 1
+    enableAlphaDilation: 0
+  secondaryTextureSettings: {}
+  variantMultiplier: 1
+  bindAsDefault: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/EOF/Assets/Atlas/skeleton_king_Atlas.spriteatlasv2
+++ b/EOF/Assets/Atlas/skeleton_king_Atlas.spriteatlasv2
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!612988286 &1
+SpriteAtlasAsset:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 2
+  m_MasterAtlas: {fileID: 0}
+  m_ImporterData:
+    packables:
+    - {fileID: 102900000, guid: 006dde85886cb400abc88727c2a0804f, type: 3}
+  m_IsVariant: 0
+  m_ScriptablePacker: {fileID: 0}

--- a/EOF/Assets/Atlas/skeleton_king_Atlas.spriteatlasv2.meta
+++ b/EOF/Assets/Atlas/skeleton_king_Atlas.spriteatlasv2.meta
@@ -1,0 +1,30 @@
+fileFormatVersion: 2
+guid: 5c47530ed7c77b24eb07b544e6ec896b
+SpriteAtlasImporter:
+  externalObjects: {}
+  textureSettings:
+    serializedVersion: 2
+    anisoLevel: 1
+    compressionQuality: 50
+    maxTextureSize: 2048
+    textureCompression: 0
+    filterMode: 1
+    generateMipMaps: 0
+    readable: 0
+    crunchedCompression: 0
+    sRGB: 1
+  platformSettings: []
+  packingSettings:
+    serializedVersion: 2
+    padding: 4
+    blockOffset: 1
+    allowAlphaSplitting: 0
+    enableRotation: 0
+    enableTightPacking: 0
+    enableAlphaDilation: 0
+  secondaryTextureSettings: {}
+  variantMultiplier: 1
+  bindAsDefault: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/EOF/Assets/Atlas/werewolfAtlas.spriteatlasv2
+++ b/EOF/Assets/Atlas/werewolfAtlas.spriteatlasv2
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!612988286 &1
+SpriteAtlasAsset:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 2
+  m_MasterAtlas: {fileID: 0}
+  m_ImporterData:
+    packables:
+    - {fileID: 102900000, guid: 0d5b530e9b6a14e9ba9f77e49313dd14, type: 3}
+  m_IsVariant: 0
+  m_ScriptablePacker: {fileID: 0}

--- a/EOF/Assets/Atlas/werewolfAtlas.spriteatlasv2.meta
+++ b/EOF/Assets/Atlas/werewolfAtlas.spriteatlasv2.meta
@@ -1,0 +1,30 @@
+fileFormatVersion: 2
+guid: fb0b37ad8634ede4189bf6088207c986
+SpriteAtlasImporter:
+  externalObjects: {}
+  textureSettings:
+    serializedVersion: 2
+    anisoLevel: 1
+    compressionQuality: 50
+    maxTextureSize: 2048
+    textureCompression: 0
+    filterMode: 1
+    generateMipMaps: 0
+    readable: 0
+    crunchedCompression: 0
+    sRGB: 1
+  platformSettings: []
+  packingSettings:
+    serializedVersion: 2
+    padding: 4
+    blockOffset: 1
+    allowAlphaSplitting: 0
+    enableRotation: 0
+    enableTightPacking: 0
+    enableAlphaDilation: 0
+  secondaryTextureSettings: {}
+  variantMultiplier: 1
+  bindAsDefault: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
아틀라스로 묶을 수 있는 스프라이트들 아틀라스 패킹

아틀라스에 들어가는 파일은 이중 압축이 되니 원본 에셋 압축은 None으로 설정

AllowRotation 체크 해제  
UI가 회전되어 출력되는 현상 방지

외부 에셋스토어 에셋은 관리가 어려우니 아틀라스 패킹 고려 대상에서 제외

퍼즐과 스킬아이콘, 통상적으로 자주 사용되는 이미지들을 각자 아틀라스로 패킹함